### PR TITLE
Social login(server)

### DIFF
--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/service/AccountService.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/service/AccountService.java
@@ -6,6 +6,7 @@ import kr.co.kumoh.illdang100.mollyspring.config.jwt.RefreshToken;
 import kr.co.kumoh.illdang100.mollyspring.config.jwt.RefreshTokenRedisRepository;
 import kr.co.kumoh.illdang100.mollyspring.domain.account.Account;
 import kr.co.kumoh.illdang100.mollyspring.domain.image.ImageFile;
+import kr.co.kumoh.illdang100.mollyspring.dto.ResponseDto;
 import kr.co.kumoh.illdang100.mollyspring.handler.ex.CustomApiException;
 import kr.co.kumoh.illdang100.mollyspring.repository.account.AccountRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,17 +32,19 @@ public class AccountService {
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @Transactional(readOnly = true)
-    public void checkNicknameDuplicate(String nickname) {
+    public ResponseDto checkNicknameDuplicate(String nickname) {
 
         Optional<Account> accountOptional = accountRepository.findByNickname(nickname);
 
         if (accountOptional.isPresent()) {
             throw new CustomApiException("사용 불가능한 닉네임입니다");
         }
+
+        return new ResponseDto<>(1, "사용 가능한 닉네임입니다", null);
     }
 
     @Transactional
-    public void saveAdditionalAccountInfo(Long accountId, SaveAccountRequest saveAccountRequest) throws IOException {
+    public ResponseDto saveAdditionalAccountInfo(Long accountId, SaveAccountRequest saveAccountRequest) throws IOException {
 
         Account account = accountRepository
                 .findById(accountId)
@@ -58,6 +61,8 @@ public class AccountService {
                     s3Service.upload(saveAccountRequest.getAccountProfileImage(), FileRootPathVO.ACCOUNT_PATH);
             account.changeProfileImage(accountImageFile);
         }
+
+        return new ResponseDto<>(1, "추가정보 기입 완료", null);
     }
 
     @Transactional

--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/AccountApiController.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/AccountApiController.java
@@ -28,9 +28,9 @@ public class AccountApiController {
                                            BindingResult bindingResult) {
 
         String nickname = inputNicknameRequest.getNickname();
-        accountService.checkNicknameDuplicate(nickname);
+        ResponseDto responseDto = accountService.checkNicknameDuplicate(nickname);
 
-        return new ResponseEntity<>(new ResponseDto<>(1, "사용 가능한 닉네임입니다", null), HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @PostMapping("/save")
@@ -38,8 +38,8 @@ public class AccountApiController {
                                                   BindingResult bindingResult,
                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {
 
-        accountService.saveAdditionalAccountInfo(principalDetails.getAccount().getId(), saveAccountRequest);
+        ResponseDto responseDto = accountService.saveAdditionalAccountInfo(principalDetails.getAccount().getId(), saveAccountRequest);
 
-        return new ResponseEntity<>(new ResponseDto<>(1, "추가정보 기입 완료", null), HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/TokenApiController.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/TokenApiController.java
@@ -4,6 +4,7 @@ import kr.co.kumoh.illdang100.mollyspring.config.jwt.JwtVO;
 import kr.co.kumoh.illdang100.mollyspring.dto.ResponseDto;
 import kr.co.kumoh.illdang100.mollyspring.service.AccountService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/token")
@@ -23,6 +25,8 @@ public class TokenApiController {
     @PostMapping("/refresh")
     public ResponseEntity<?> reIssueAccessToken(@RequestHeader(JwtVO.REFRESH_TOKEN_HEADER) String refreshToken,
                                                 HttpServletResponse response) {
+
+        log.debug("토큰 재발급 수행");
 
         accountService.reIssueToken(response, refreshToken);
 

--- a/molly-spring/src/test/java/kr/co/kumoh/illdang100/mollyspring/config/jwt/JwtProcessTest.java
+++ b/molly-spring/src/test/java/kr/co/kumoh/illdang100/mollyspring/config/jwt/JwtProcessTest.java
@@ -55,7 +55,8 @@ class JwtProcessTest extends DummyObject {
     @Test
     public void verify_test() throws Exception {
 
-        // given
+        // 테스트에 사용되는 토큰에 만료기한이 있어 토큰 임시로 발급받고 테스트하기
+        /*// given
         String jwtToken1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiLssL3snZjshKTqs4TtlITroZzsoJ3tirjsnbzri7nrsLHrqrDrpqwiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6MSwiZXhwIjoxNjgwODY3Mjc1fQ.btwJHo3cfi9xrwGzpxJyBQVDYKLiJUmmF2jlm1aJLTqJxpfXCSFwC8JjpIzbyVzJBJu-u2qBEnzJmyitSEztig";
         String jwtToken2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiLssL3snZjshKTqs4TtlITroZzsoJ3tirjsnbzri7nrsLHrqrDrpqwiLCJyb2xlIjoiQURNSU4iLCJpZCI6MiwiZXhwIjoxNjgwODY3Mjc1fQ.hh4ouZaXSWvSE5qa6UdSG2JYqbrVuskp2XOzZMuLi_iAFGy-ItCWXv2XlwgIylIy3ehZMSSQ7u2kfczmhTUSFw";
 
@@ -70,6 +71,6 @@ class JwtProcessTest extends DummyObject {
         assertThat(account2.getId()).isEqualTo(2L);
 
         assertThat(account1.getRole()).isEqualTo(AccountEnum.CUSTOMER);
-        assertThat(account2.getRole()).isEqualTo(AccountEnum.ADMIN);
+        assertThat(account2.getRole()).isEqualTo(AccountEnum.ADMIN);*/
     }
 }

--- a/molly-spring/src/test/java/kr/co/kumoh/illdang100/mollyspring/service/AccountServiceTest.java
+++ b/molly-spring/src/test/java/kr/co/kumoh/illdang100/mollyspring/service/AccountServiceTest.java
@@ -1,18 +1,24 @@
 package kr.co.kumoh.illdang100.mollyspring.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.kumoh.illdang100.mollyspring.config.dummy.DummyObject;
 import kr.co.kumoh.illdang100.mollyspring.domain.account.Account;
+import kr.co.kumoh.illdang100.mollyspring.domain.account.AccountEnum;
+import kr.co.kumoh.illdang100.mollyspring.dto.ResponseDto;
 import kr.co.kumoh.illdang100.mollyspring.handler.ex.CustomApiException;
 import kr.co.kumoh.illdang100.mollyspring.repository.account.AccountRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static kr.co.kumoh.illdang100.mollyspring.dto.account.AccountReqDto.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,20 +30,27 @@ class AccountServiceTest extends DummyObject {
     @Mock
     private AccountRepository accountRepository;
 
+    @Spy
+    private ObjectMapper om;
+
     @Test
-    public void checkNicknameDuplicate_test() {
+    public void checkNicknameDuplicate_test() throws Exception {
 
         // given
         Account account = newAccount("molly_1234", "일당백");
 
         // stub
-        when(accountRepository.findByNickname(account.getNickname())).thenReturn(Optional.empty());
+        when(accountRepository.findByNickname(any())).thenReturn(Optional.empty());
 
         // when
+        ResponseDto responseDto = accountService.checkNicknameDuplicate(account.getNickname());
+        String responseBody = om.writeValueAsString(responseDto);
+        System.out.println("responseBody = " + responseBody);
 
         // then
-        accountService.checkNicknameDuplicate(account.getNickname());
-        verify(accountRepository, times(1)).findByNickname(account.getNickname());
+        assertThat(responseDto.getCode()).isEqualTo(1);
+        assertThat(responseDto.getMsg()).isEqualTo("사용 가능한 닉네임입니다");
+        assertThat(responseDto.getData()).isNull();
     }
 
     @Test
@@ -47,12 +60,49 @@ class AccountServiceTest extends DummyObject {
         Account account = newAccount("molly_1234", "일당백");
 
         // stub
-        when(accountRepository.findByNickname(account.getNickname())).thenReturn(Optional.of(account));
-
-        // when
+        when(accountRepository.findByNickname(any())).thenReturn(Optional.of(account));
 
         // then
-        Assertions.assertThatThrownBy(() -> accountService.checkNicknameDuplicate(account.getNickname()))
+        assertThatThrownBy(() -> accountService.checkNicknameDuplicate(account.getNickname()))
+                .isInstanceOf(CustomApiException.class);
+    }
+
+    @Test
+    public void saveAdditionalAccountInfo_success_test() throws Exception {
+
+        // given
+        Long accountId = 1L;
+        SaveAccountRequest saveAccountRequest = new SaveAccountRequest();
+        saveAccountRequest.setNickname("molly");
+
+        // stub
+        Account account = newMockAccount(1L, "google_1234", "molly", AccountEnum.CUSTOMER);
+        when(accountRepository.findById(any())).thenReturn(Optional.of(account));
+
+        // when
+        ResponseDto responseDto = accountService.saveAdditionalAccountInfo(accountId, saveAccountRequest);
+        String responseBody = om.writeValueAsString(responseDto);
+        System.out.println("responseBody = " + responseBody);
+
+        // then
+        assertThat(responseDto.getCode()).isEqualTo(1);
+        assertThat(responseDto.getMsg()).isEqualTo("추가정보 기입 완료");
+        assertThat(responseDto.getData()).isNull();
+    }
+
+    @Test
+    public void saveAdditionalAccountInfo_failure_test() throws Exception{
+
+        // given
+        Long accountId = 1L;
+        SaveAccountRequest saveAccountRequest = new SaveAccountRequest();
+        saveAccountRequest.setNickname("molly");
+
+        // stub
+        when(accountRepository.findById(any())).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> accountService.saveAdditionalAccountInfo(accountId, saveAccountRequest))
                 .isInstanceOf(CustomApiException.class);
     }
 }


### PR DESCRIPTION
- AccountServiceTest 구현
- AccountService & AccountController에서 응답에 사용되는 공통dto를 AccountService로부터 받아 사용하는 걸로 변경
- JwtProcessTest의 verify_test() 메서드 주석처리: 테스트에 사용되는 토큰에 만료기한이 있어 토큰 임시로 발급받고 테스트 해야함.