### PR TITLE
Pet feat(server)

### DIFF
--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/dto/pet/PetRespDto.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/dto/pet/PetRespDto.java
@@ -68,6 +68,7 @@ public class PetRespDto {
     }
 
     @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class PetHomeResponse {
         private List<PetHomeDetailResponse> pet;

--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/service/MedicationService.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/service/MedicationService.java
@@ -65,8 +65,7 @@ public class MedicationService {
         findPetOrElseThrow(petId);
 
         List<MedicationHistory> mHistory = medicationRepository.findByPet_IdOrderByMedicationStartDateAsc(petId);
-        if (mHistory.isEmpty()) throw new CustomApiException("복용약 기록이 존재하지 않습니다.");
-
+        if (mHistory.isEmpty()) return null;
         return mHistory.stream()
                 .map(m -> new MedicationResponse(m.getId(), m.getMedicationName(), m.getMedicationStartDate(), m.getMedicationEndDate()))
                 .collect(Collectors.toList());
@@ -77,8 +76,7 @@ public class MedicationService {
      * @param request
      */
     @Transactional
-    public void updateMedication(MedicationUpdateRequest request) {
-        Long petId = request.getPetId();
+    public void updateMedication(Long petId, MedicationUpdateRequest request) {
         findPetOrElseThrow(petId);
 
         Long medicationId = request.getMedicationId();

--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/service/SurgeryService.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/service/SurgeryService.java
@@ -61,8 +61,8 @@ public class SurgeryService {
     public List<SurgeryResponse> viewSurgeryList(Long petId) {
 
         List<SurgeryHistory> sHistory = surgeryRepository.findByPet_IdOrderBySurgeryDateAsc(petId);
-       if (sHistory == null) throw new CustomApiException("수술 이력이 존재하지 않습니다");
-       return sHistory.stream()
+        if (sHistory.isEmpty()) return null;
+        return sHistory.stream()
                .map(s -> new SurgeryResponse(s.getId(), s.getSurgeryName(), s.getSurgeryDate()))
                .collect(Collectors.toList());
     }
@@ -72,8 +72,7 @@ public class SurgeryService {
      * @param request
      */
     @Transactional
-    public void updateSurgery(SurgeryUpdateRequest request) {
-        Long petId = request.getPetId();
+    public void updateSurgery(Long petId, SurgeryUpdateRequest request) {
         findPetOrElseThrow(petId);
 
         Long surgeryId = request.getSurgeryId();

--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/HomeApiController.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/HomeApiController.java
@@ -1,0 +1,27 @@
+package kr.co.kumoh.illdang100.mollyspring.web;
+
+import kr.co.kumoh.illdang100.mollyspring.dto.ResponseDto;
+import kr.co.kumoh.illdang100.mollyspring.dto.pet.PetRespDto.PetHomeResponse;
+import kr.co.kumoh.illdang100.mollyspring.security.auth.PrincipalDetails;
+import kr.co.kumoh.illdang100.mollyspring.service.PetService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth/home")
+@RequiredArgsConstructor
+public class HomeApiController {
+    private final PetService petService;
+    @GetMapping
+    public ResponseEntity<?> getHome(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        PetHomeResponse homeResponse = petService.getHome(principalDetails.getAccount().getId());
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "홈화면 정보", homeResponse), HttpStatus.OK);
+    }
+}

--- a/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/PetApiController.java
+++ b/molly-spring/src/main/java/kr/co/kumoh/illdang100/mollyspring/web/PetApiController.java
@@ -32,23 +32,23 @@ public class PetApiController {
                                          BindingResult bindingResult,
                                          @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        Long petId = petService.registerPet(petSaveRequest, principalDetails.getAccount());
+        PetSaveResponse petSaveResponse = petService.registerPet(petSaveRequest, principalDetails.getAccount().getId());
 
-        return new ResponseEntity<>(new ResponseDto(1, "반려동물 등록을 성공했습니다.", new PetSaveResponse(petId)), HttpStatus.CREATED);
+        return new ResponseEntity<>(new ResponseDto(1, "반려동물 등록을 성공했습니다.", petSaveResponse), HttpStatus.CREATED);
     }
     @GetMapping("{petId}")
-    public ResponseEntity<?> viewDetails(@PathVariable @NotNull Long petId) {
-
-        PetDetailResponse petDetailResponse = petService.viewDetails(petId);
+    public ResponseEntity<?> viewDetails(@PathVariable @NotNull Long petId,
+                                         @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        PetDetailResponse petDetailResponse = petService.viewDetails(petId, principalDetails.getAccount().getId());
 
         return new ResponseEntity<>(new ResponseDto(1, "해당 반려동물의 정보입니다.", petDetailResponse), HttpStatus.OK);
     }
     @PostMapping("{petId}")
-    public ResponseEntity<?> updatePet(@RequestBody @Valid PetUpdateRequest petUpdateRequest,
+    public ResponseEntity<?> updatePet(@PathVariable @NotNull Long petId,  @RequestBody @Valid PetUpdateRequest petUpdateRequest,
                                        BindingResult bindingResult,
                                        @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        petService.updatePet(petUpdateRequest, principalDetails.getAccount());
+        petService.updatePet(petId, petUpdateRequest, principalDetails.getAccount().getId());
 
         return new ResponseEntity<>(new ResponseDto(1, "반려동물 정보 수정을 성공했습니다.", null), HttpStatus.OK);
     }
@@ -61,7 +61,7 @@ public class PetApiController {
         return new ResponseEntity<>(new ResponseDto(1, "반려동물 삭제를 성공했습니다.", null), HttpStatus.OK);
     }
 
-    @PostMapping(path = "/image")
+    @PostMapping("/image")
     public ResponseEntity<?> updatePetProfileImage(@ModelAttribute @Valid PetProfileImageUpdateRequest petProfileImageUpdateRequest,
                                                    BindingResult bindingResult) {
 
@@ -75,7 +75,7 @@ public class PetApiController {
 
         petService.deletePetProfileImage(petId);
 
-        return new ResponseEntity<>(new ResponseDto(1, "반려동물 프로필 이미지를 기본 이미지로 변경했습니다..", null), HttpStatus.OK);
+        return new ResponseEntity<>(new ResponseDto(1, "반려동물 프로필 이미지를 기본 이미지로 변경했습니다.", null), HttpStatus.OK);
     }
 
     @GetMapping("/dog-species")


### PR DESCRIPTION
- HomeApiController 생성
- PetApiController 수정
  - 반려동물 등록 시 수술, 복용약, 예방접종 이력도 같이 추가하도록 변경
  - 반려동물 조회 시 해당 account의 pet인지 검사하기 위해 @AuthenticationPrincipal PrincipalDetails principalDetails 파라미터로 받아옴
  - petService 메서드 호출 시 파라미터에 account 객체 대신 account의 id를 넣어주도록 변경
- PetHomeResponse NoArgsConstructor 어노테이션 추가
- SurgeryUpdateRequest, MedicationUpdateRequest petId 필드 삭제
  - MedicationService updateMedication, SurgeryService updateSurgery 메소드 수정